### PR TITLE
Speed up FFT

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,14 +21,18 @@ lib_deps =
     adafruit/Adafruit GFX Library@^1.11.0
 	adafruit/Adafruit BusIO@^1.11.5
 	FastLED
-    kosme/arduinoFFT @ ^1.6
+    kosme/arduinoFFT @ ^2.0.0
 
 srcfilter = +<*>
 
 [env:hat]
-src_filter =
+build_src_filter =
 	${env.srcfilter}
 	-<controller.cpp>
+
+; Switch -Os (which is on by default) off, and -O3 on
+build_unflags = -Os
+build_flags = -O3
 
 ; Com port which your hat ESP32 is connected via
 upload_port = COM7


### PR DESCRIPTION
See [faster_ffd.md](https://github.com/JonLD/led_hat_v2/blob/george/fft-timing-investigation/faster_fft.md) on george/fft-timing-investigation for full details. The code needed to reproduce those results should be present in the commits on that branch too.
 Makes three high-level changes:
* Optimise use of arduinoFFT library, by defining macros and caching windowing
* Use floats instead of doubles in FFT (as ESP32 has no double hardware support)
* Use -O3 instead of -Os as we don't appear to be space-limited

This will need testing on the hat itself; I'm not sure that I've actually preserved behaviour :D

To mitigate float/double concerns: float should be good for 6 decimal places, which is far beyond what is human-perceptible.