### PR TITLE
Use hardware timer rather than FastLED helper, and fix freq band analysis

### DIFF
--- a/src/beat_detection.cpp
+++ b/src/beat_detection.cpp
@@ -6,6 +6,7 @@
 #define FFT_SPEED_OVER_PRECISION
 #include <arduinoFFT.h>
 
+#include "timing.h"
 #include "profiling.h"
 
 #define BEAT_DEBOUNCE_DURATION_MS 200
@@ -69,7 +70,7 @@ void ComputeFFT(int32_t rawMicSamples[FFT_BUFFER_LENGTH])
     FFT.windowing(FFT_WIN_TYP_HAMMING, FFT_FORWARD);
     FFT.compute(FFTDirection::Forward);
     FFT.complexToMagnitude();
-    
+
     AnalyzeFrequencyBand(&bassFreqData);
     AnalyzeFrequencyBand(&midFreqData);
 }
@@ -93,7 +94,7 @@ void DetectBeat()
 {
     const bool isBassAboveAvg = IsMagAboveThreshold(bassFreqData);
     const bool isMidAboveAvg = IsMagAboveThreshold(midFreqData);
-    const bool isNoRecentBeat = ((millis() - lastBeatTime_ms) > (BEAT_DEBOUNCE_DURATION_MS));
+    const bool isNoRecentBeat = (GetMillis() - lastBeatTime_ms) > (BEAT_DEBOUNCE_DURATION_MS);
     const bool peakIsBass = (FFT.majorPeak() < MAX_BASS_FREQUENCY_HZ);
     const bool isAvgBassAboveMin = (bassFreqData.averageMagnitude > bassFreqData.minMagnitude);
     const float proportionBassAboveAvg = ProportionOfMagAboveAvg(bassFreqData);
@@ -124,7 +125,7 @@ void DetectBeat()
 
     if (isBeatDetected)
     {
-        lastBeatTime_ms = millis();
+        lastBeatTime_ms = GetMillis();
 #ifdef PRINT_BIN_MAGNITUDES
         PrintVector(vReal, NUMBER_OF_SAMPLES, SCL_FREQUENCY);
         delay(20000);
@@ -157,4 +158,3 @@ static float ProportionOfMagAboveAvg(freqBandData_t freqBandData)
     const float proportionAboveAvg = (bassFreqData.currentMagnitude / bassFreqData.averageMagnitude);
     return proportionAboveAvg;
 }
-

--- a/src/hat.cpp
+++ b/src/hat.cpp
@@ -9,6 +9,7 @@
 #include "effects.h"
 #include "i2s_mic.h"
 #include "interface.h"
+#include "timing.h"
 #include "profiling.h"
 
 #define AMBIENT_EFFECT_TIMEOUT_MS 1000
@@ -134,13 +135,13 @@ static void EffectSelectionEngine()
         isAmbientSection = false;
         currentEffect = beatEffectEnumValues[random(size(beatEffectEnumValues))];
     }
-    else if (millis() - lastBeatTime_ms > AMBIENT_EFFECT_TIMEOUT_MS && !isAmbientSection)
+    else if (GetMillis() - lastBeatTime_ms > AMBIENT_EFFECT_TIMEOUT_MS && !isAmbientSection)
     {
         isAmbientSection = true;
         currentEffect = ambientEffectEnumValues[random(size(ambientEffectEnumValues))];
     }
     // TODO: seems to be a bit broken with this
-    // else if (millis() - lastBeatTime_ms > BEAT_EFFECT_TIMEOUT_MS && !isAmbientSection)
+    // else if (GetMillis() - lastBeatTime_ms > BEAT_EFFECT_TIMEOUT_MS && !isAmbientSection)
     // {
     //     currentEffect = static_cast<Effect>(beatEffectEnumValues[random(size(beatEffectEnumValues))]);
     // }

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -9,8 +9,8 @@
 #define FFT_SPEED_OVER_PRECISION
 #include <arduinoFFT.h>
 
-unsigned long lastProfilingPoint_ms;
-unsigned long microsNow;
+int64_t lastProfilingPoint_ms;
+int64_t microsNow;
 
 // Print various data for debugging
 void PrintVector(float *vData, uint16_t bufferSize, uint8_t scaleType)

--- a/src/profiling.h
+++ b/src/profiling.h
@@ -3,6 +3,8 @@
 
 #include <arduino.h>
 
+#include "timing.h"
+
 #define SCL_INDEX 0x00
 #define SCL_TIME 0x01
 #define SCL_FREQUENCY 0x02
@@ -19,13 +21,13 @@
 
 
 
-extern unsigned long lastProfilingPoint_ms;
-extern unsigned long microsNow;
+extern int64_t lastProfilingPoint_ms;
+extern int64_t microsNow;
 
 #ifdef TIME_PROFILING
 #define BPS_PROFILING
 #define EMIT_PROFILING_EVENT {\
-    microsNow = micros();\
+    microsNow = GetMicros();\
     Serial.print(microsNow - lastProfilingPoint_ms);\
     Serial.print("\t");\
     lastProfilingPoint_ms = microsNow;\
@@ -36,7 +38,7 @@ extern unsigned long microsNow;
 
 #ifdef PROFILE_MIC_READ
 #define EMIT_MIC_READ_EVENT {\
-    microsNow = micros();\
+    microsNow = GetMicros();\
     Serial.println(microsNow - lastProfilingPoint_ms);\
     lastProfilingPoint_ms = microsNow;\
 }

--- a/src/timing.h
+++ b/src/timing.h
@@ -1,0 +1,20 @@
+#ifndef TIMING_H
+#define TIMING_H
+
+#include <Arduino.h>
+
+// Get the current number of micros since power on, from the ESP's hardware timer.
+// This would wrap after (2^64) / (10^6 * 60 * 60 * 24 * 365) = 584942 years
+inline int64_t GetMicros(void)
+{
+    return esp_timer_get_time();
+}
+
+// Get the current number of millis since power on, from the ESP's hardware timer.
+inline int64_t GetMillis(void)
+{
+    return (GetMicros() / 1000u);
+}
+
+
+#endif // TIMING_H


### PR DESCRIPTION
* Use `esp_timer_get_time()` in place of FastLED's `millis()` and `micros()`, to hopefully improve performance.
* Turn "on" mid-freq analysis by refining the way `IsMagAboveThreshold` works

I plan on merging without squashing these two commits as they do separate things